### PR TITLE
Update script names in home-assistant example

### DIFF
--- a/example_configs/home-assistant.md
+++ b/example_configs/home-assistant.md
@@ -6,8 +6,8 @@ Home Assistant configures ldap auth via the [Command Line Auth Provider](https:/
 
 The [auth script](lldap-ha-auth.sh) attempts to authenticate a user against an LLDAP server, using credentials provided via `username` and `password` environment variables. The first argument must be the URL of your LLDAP server, accessible from Home Assistant. You can provide an additional optional argument to confine allowed logins to a single group. The script will output the user's display name as the `name` variable, if not empty.
 
-1. Copy the [auth script](lldap-ha-auth.sh) to your home assistant instance. In this example, we use `/config/lldap-auth.sh`.
-      - Set the script as executable by running `chmod +x /config/lldap-auth.sh`
+1. Copy the [auth script](lldap-ha-auth.sh) to your home assistant instance. In this example, we use `/config/lldap-ha-auth.sh`.
+      - Set the script as executable by running `chmod +x /config/lldap-ha-auth.sh`
 2. Add the following to your configuration.yaml in Home assistant:
 ```yaml
 homeassistant:
@@ -15,7 +15,7 @@ homeassistant:
     # Ensure you have the homeassistant provider enabled if you want to continue using your existing accounts
     - type: homeassistant
     - type: command_line
-      command: /config/lldap-auth.sh
+      command: /config/lldap-ha-auth.sh
       # Only allow users in the 'homeassistant_user' group to login.
       # Change to ["https://lldap.example.com"] to allow all users
       args: ["https://lldap.example.com", "homeassistant_user"]


### PR DESCRIPTION
The name of the script downloaded from Github did not match the example code and tripped me up until I noticed. This changes "lldap-auth.sh" to "lldap-ha-auth.sh" in the examples.